### PR TITLE
feat: add DIN Next LT Arabic font

### DIFF
--- a/paragon/_fonts.scss
+++ b/paragon/_fonts.scss
@@ -1,1 +1,11 @@
 // Add any font imports or definitions here
+@font-face {
+  font-family: 'DIN Next LT Arabic';
+  src: url('https://futurex-edxapp-production.s3.eu-west-1.amazonaws.com/certificate_template_assets/11/din-next-lt-arabic-bold.ttf');
+  font-weight: normal;
+  font-style: normal;
+}
+
+:root {
+  --pgn-typography-font-family-base: 'DIN Next LT Arabic',var(--pgn-typography-font-family-sans-serif) !important;
+}


### PR DESCRIPTION
## Description

This is a cherry pick of https://github.com/nelc/brand-openedx/pull/1  and basically adds the `DIN Next LT Arabic` font
https://edunext.atlassian.net/browse/FUTUREX-544

## Result

![image](https://github.com/nelc/brand-openedx/assets/36200299/7aba8f1d-4656-4202-b9ea-50a6370d4864)


### How to test
1. checkout this branch
2.  Add the following configuration to your  module.config.js file 

```
module.exports = {
    localModules: [
        { moduleName: '@edx/brand', dir: '../brand-openedx'},
        { moduleName: '@edx/paragon/styles/scss/core', dir: '../paragon', dist: 'styles/scss/core' },
        { moduleName: '@edx/paragon/icons', dir: '../paragon', dist: 'icons' },
        { moduleName: '@edx/paragon', dir: '../paragon', dist: 'src' },
    ],
};
```
3. Reload your container
4. Check your MFE

**Note** You have to use  the paragon alpha version 
