### PR TITLE
feat: add default light theme variables and styles

### DIFF
--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -1,2 +1,5 @@
 // Use this file to define style overrides for @edx/paragon
 // This file is included after all Paragon styles, but should generally avoid using private mixins in Paragon.
+
+@import "~@edx/paragon/styles/css/themes/light/variables";
+@import "~@edx/paragon/styles/css/themes/light/utility-classes";


### PR DESCRIPTION
## Description

The paragon implementation of this [branch](https://github.com/nelc/paragon/tree/open-release/palm.nelp) split its styles in themes ( currently just light ) that causes that the page looks like this:

![image](https://github.com/nelc/brand-openedx/assets/36200299/c9246226-17b8-424c-89ca-03bfb73d6a44)


After this the page looks like this:
![image](https://github.com/nelc/brand-openedx/assets/36200299/73c3b3f3-a129-4566-a783-b3476a2a4092)
