### PR TITLE
feat: add default light theme variables and styles

### DIFF
--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -1,2 +1,8 @@
 // Use this file to define style overrides for @edx/paragon
 // This file is included after all Paragon styles, but should generally avoid using private mixins in Paragon.
+
+@import "~@edx/paragon/styles/css/themes/light/variables";
+@import "~@edx/paragon/styles/css/themes/light/utility-classes";
+
+@import url('https://cdn.jsdelivr.net/npm/@openedx/paragon@23.0.0-alpha.1/styles/css/themes/light/utility-classes.min.css');
+@import url('https://cdn.jsdelivr.net/npm/@openedx/paragon@23.0.0-alpha.1/dist/core.min.css');


### PR DESCRIPTION
## Description 
This sets default values when the `PARAGON_THEME_URLS` setting has not been set  [issue](https://edunext.atlassian.net/browse/FUTUREX-968)

## How to test with app learning
1. Clone paragon and brand-openedx repo into the src/mfe folder (with right versions paragon=V23.0.0-alpha.1 from openedx repo  brand-openedx=open-release/redwood.nelp from nelc repo)
2. Add the module.config.js file into the frontend-app-learning folder
```js
module.exports = {
    localModules: [
        { moduleName: '@edx/brand', dir: '../brand-openedx'},
        { moduleName: '@edx/paragon/styles/css/themes', dir: '../paragon', dist: 'styles/css/themes' },
        { moduleName: '@edx/paragon/styles/css/core', dir: '../paragon', dist: 'styles/css/core' },
        { moduleName: '@edx/paragon/styles/scss/core', dir: '../paragon', dist: 'styles/scss/core' },
        { moduleName: '@edx/paragon/icons', dir: '../paragon', dist: 'icons' },
        { moduleName: '@edx/paragon', dir: '../paragon', dist: 'src' },
    ],
};
```
3. Restart the learning mfe service, docker attach container and then ctrl+c
4. checkout this branch
5. if you have set `PARAGON_THEME_URLS` delete it from the `MFE_CONFIG`
6. Go to any course page and check 

## Before
![image](https://github.com/user-attachments/assets/213199ad-9766-4d9f-9e53-6b58e7060f2a)


## After
![image](https://github.com/user-attachments/assets/da7f15f9-d56c-4d00-aa91-9b1a5d154efe)



