### PR TITLE
feat: set default typography

### DIFF
--- a/paragon/_fonts.scss
+++ b/paragon/_fonts.scss
@@ -1,1 +1,7 @@
 // Add any font imports or definitions here
+
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Arabic:wght@100;200;300;400;500;600;700&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
+
+:root {
+  --pgn-typography-font-family-base: 'IBM Plex Sans Arabic',var(--pgn-typography-font-family-sans-serif) !important;
+}


### PR DESCRIPTION
## Description
This add the default font for the NELC implementation.  

Issue # [1670](https://edunext.atlassian.net/browse/FUTUREX-1670)
Migration pr of #13 and #14



## How to test
1. Set the learning MFE as a volume
2. Add the module.config.js file into the frontend-app-learning folder and restart your container

```js
module.exports = {
    localModules: [
        { moduleName: '@edx/brand', dir: '../brand-openedx'},
    ],
};
```
3. Checkout this branch
4. In redwood the styles loaded automatically due to this [file](https://github.com/nelc/frontend-app-learning/blob/open-release/redwood.nelp/src/course-home/outline-tab/widgets/FlagButton.scss#L1C1-L2C7) however those lines were removed in this version so you have to import  the brand package explicitly in the `frontend-app-learning/src/index.scss` file, add the following lines at the top of the file after the last import statement.
```
@import "@edx/brand/paragon/fonts";
@import "@edx/brand/paragon/variables";
@import "@edx/brand/paragon/overrides";
``` 

## Before
<img width="1859" height="972" alt="image" src="https://github.com/user-attachments/assets/4c22bd72-6611-4950-ad05-1f2c32134d3f" />



## After
<img width="1859" height="972" alt="image" src="https://github.com/user-attachments/assets/6b306b35-f983-4bd1-be44-0bd697ec47ab" />
